### PR TITLE
Solving unhandled event error for IUT Ready Event.

### DIFF
--- a/pybtp/btp_worker.py
+++ b/pybtp/btp_worker.py
@@ -45,7 +45,7 @@ class BTPWorker:
                 data = self.btp_socket.read(timeout=1.0)
 
                 hdr = data[0]
-                if hdr.op >= 0x80:
+                if hdr.svc_id != defs.BTP_SERVICE_ID_CORE and hdr.op >= 0x80:
                     # Do not put handled events on RX queue
                     if self.event_handler_cb:
                         ret = self.event_handler_cb(*data)


### PR DESCRIPTION
At beginning of each test case, BTPTesterCore is resetting BOARD and wait for the IUT_READY Event.
This event is received at the btp_worker task, but there is no registered call back for it. hence the following error happened.

: Unhandled event! svc_id 0 op 128

We are waiting for this event at wait_iut_ready_event at iutctl.py

by this fix, we exclude the IUT READY EVENT from being handled by callbacks and handled only at wait_iut_ready_event.
 