### PR TITLE
btp: Solving bug in gattc_write_without_rsp

### DIFF
--- a/pybtp/btp.py
+++ b/pybtp/btp.py
@@ -1848,7 +1848,7 @@ def gattc_write_without_rsp(iutctl: IutCtl, bd_addr: BleAddress, hdl, val,
     if val_mtp:
         val *= int(val_mtp)
 
-    data_ba = bytearray()
+    data_ba = bytearray(bd_addr)
 
     hdl_ba = struct.pack('H', hdl)
     val_ba = binascii.unhexlify(bytearray(val))


### PR DESCRIPTION
We don't add bd_addr in the gattc_write_without_rsp btp command, That's why this command is failing.