### PR TITLE
Test output saving and test time scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ testcases.
   - socat
   - adb (when testing with Android)
   - virtualenv (recommended)
+  - at (optional for run scheduling)
 
 - pip install -r requirements.txt
 
@@ -120,8 +121,12 @@ runner = unittest.TextTestRunner(verbosity=2)
 runner.run(suite())
 ```
 
-A working example can be found in `main.py` file.
-
+A working example can be found in `main.py` file. It can be run also from test.sh script.
+Running `main.py` from `test.sh` will generate two `.log` files: `logger_traces.log` with
+history of run functions and their outputs and `test.log` with reports of executed tests.
+If running test from shell script, user can define time when  tests will be run. At accepts
+many time formats,  i.e. date in format 2020-04-30, time in form 09:20 or 0920 and 
+now + n minute, hour, day.
 
 #### Testcase naming convention
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@
 import argparse
 import logging
 import unittest
+import sys
 
 from common.board import NordicBoard
 from projects.android.iutctl import AndroidCtl
@@ -32,6 +33,7 @@ def main():
     format = ("%(asctime)s %(levelname)s %(threadName)-20s "
               "%(filename)-25s %(lineno)-5s %(funcName)-25s : %(message)s")
     logging.basicConfig(level=logging.DEBUG,
+                        filename='logger_traces.log',
                         format=format)
     logger = logging.getLogger('websockets.server')
     logger.setLevel(logging.ERROR)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# check if test process already exists and if it does, terminate it.
+# This is used to end existing communication with devices and assure,
+# that tests are run fresh and thus replicable
+
+pkill -f "btptester main.py" # this sends SIGKILL
+exec -a btptester python3 main.py &>test.log | at now + 0 minute
+exit 0


### PR DESCRIPTION
- history of called functions is now saved in "logger_traces.log"
- test results are saved in test.log
- added Linux "at" command support to schedule test runs
- script will terminate existing processes with fitting name to prevent simultanious running of few test and blocking communication with devices. This will assure that each time tests will run fresh