### PR TITLE
Fix of process() method

### DIFF
--- a/defensics/btp_automation_handler.py
+++ b/defensics/btp_automation_handler.py
@@ -55,7 +55,7 @@ class BTPAutomationHandler(threading.Thread):
             logging.debug("Acquire lock")
             self.test_case_handler.test_case_setup(self.iut)
             # Execute test handler
-            hdl(self.iut, valid)
+            hdl(self.test_case_handler, self.iut, valid)
             self.test_case_handler.test_case_teardown(self.iut)
             logging.debug("Release lock")
             self.processing_lock.release()


### PR DESCRIPTION
In process() method hdl() is member function, so object must be passed as argument to work.