### PR TITLE
Defensics: import cleanup in coap

### DIFF
--- a/defensics/coap_main.py
+++ b/defensics/coap_main.py
@@ -15,9 +15,9 @@ from defensics.coap_proxy import CoapProxy, DEVICE_ADDR
 from defensics.udp_server import UDPServer
 
 try:
-    from gi.repository import GObject
+    from gi.repository import GLib
 except ImportError:
-    import gobject as GObject
+    import gobject as GLib
 
 
 def main():
@@ -37,7 +37,7 @@ def main():
 
     (options, args) = parser.parse_args()
 
-    mainloop = GObject.MainLoop()
+    mainloop = GLib.MainLoop()
     udp = UDPServer('127.0.0.1', 5683)
     proxy = CoapProxy(DEVICE_ADDR, options.dev_id)
 

--- a/defensics/coap_proxy.py
+++ b/defensics/coap_proxy.py
@@ -9,10 +9,6 @@ import dbus.mainloop.glib
 from pybtp.utils import wait_futures
 from testcases.utils import EV_TIMEOUT
 
-try:
-    from gi.repository import GObject
-except ImportError:
-    import gobject as GObject
 
 BLUEZ_SERVICE = "org.bluez"
 ADAPTER_INTERFACE = BLUEZ_SERVICE + ".Adapter1"


### PR DESCRIPTION
Solved: 'GObject.MainLoop is deprecated; use GLib.MainLoop instead' and removed unused imports from coap_proxy.py